### PR TITLE
Add GitHub mirror information

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,6 @@ The main Chromium project is located at [chromium.org](https://www.chromium.org/
 
 The source code is available at <https://chromium.googlesource.com/chromium/src.git>.
 
+A GitHub mirror for the source code is available at <https://github.com/mirror/chromium>.
+
 Instructions for contributing can be found at <https://www.chromium.org/for-testers>.


### PR DESCRIPTION
Unfortunately https://github.com/ChromiumWebApps/chromium stopped updating 2 years ago.