### PR TITLE
Fix conditions to call SelectNewPrimaryConfig

### DIFF
--- a/net/third_party/quic/core/crypto/quic_crypto_server_config.cc
+++ b/net/third_party/quic/core/crypto/quic_crypto_server_config.cc
@@ -518,7 +518,7 @@ void QuicCryptoServerConfig::ValidateClientHello(
       result->error_details = "No configurations loaded";
     } else {
       if (!next_config_promotion_time_.IsZero() &&
-          next_config_promotion_time_.IsAfter(now)) {
+          !next_config_promotion_time_.IsAfter(now)) {
         configs_lock_.ReaderUnlock();
         configs_lock_.WriterLock();
         SelectNewPrimaryConfig(now);
@@ -786,7 +786,7 @@ void QuicCryptoServerConfig::ProcessClientHello(
       no_primary_config = true;
     } else {
       if (!next_config_promotion_time_.IsZero() &&
-          next_config_promotion_time_.IsAfter(now)) {
+          !next_config_promotion_time_.IsAfter(now)) {
         configs_lock_.ReaderUnlock();
         configs_lock_.WriterLock();
         SelectNewPrimaryConfig(now);


### PR DESCRIPTION
When there are multiple elements in configs_  and after calling SelectNewPrimaryConfig(), the variable next_config_promotion_time_ is the future time.
in QuicCryptoServerConfig::ValidateClientHello,   When next_config_promotion_time_ becomes a past time, we should call the SelectNewPrimaryConfig function to select a new primary config.