### PR TITLE
URL Decode for Named Destinations in PDF Viewer

### DIFF
--- a/chrome/browser/resources/pdf/open_pdf_params_parser.js
+++ b/chrome/browser/resources/pdf/open_pdf_params_parser.js
@@ -116,7 +116,7 @@ window.OpenPDFParamsParser = class {
       // Handle the case of http://foo.com/bar#NAMEDDEST. This is not
       // explicitly mentioned except by example in the Adobe
       // "PDF Open Parameters" document.
-      params['nameddest'] = paramTokens[0];
+      params['nameddest'] = decodeURIComponent(paramTokens[0]);
       return params;
     }
 
@@ -125,7 +125,12 @@ window.OpenPDFParamsParser = class {
       if (keyValueSplit.length != 2) {
         continue;
       }
-      params[keyValueSplit[0]] = keyValueSplit[1];
+      var paramValue = keyValueSplit[1];
+      if(keyValueSplit[0] == 'nameddest') {
+        paramValue = decodeURIComponent(paramValue);
+      }
+      
+      params[keyValueSplit[0]] = paramValue;
     }
 
     return params;


### PR DESCRIPTION
Named Destinations in the PDF specification allow a page to be referenced by a name. The name itself can be any sequence of characters.When converting a word document to PDF, outline headings are automatically converted to Named Destinations.

If a heading contains spaces, the parameters will contain "%20" - but currently the encoding is not reversed before a lookup is performed by chrome's PDF engine. 

Therefore, when executing a URL containing a named destination, the name should be decoded back before a lookup using the named destinations dictionary is executed by Chrome's PDF engine. 

Currently this is not the case, so for any headings which contain spaces or other characters which cannot be represented via URL without encoding (such as ?&= and so on...) will not be found in the named destination lookup table. 

This change will fix this behaviour. 

References:
https://bugs.chromium.org/p/chromium/issues/detail?id=144303
https://bugs.chromium.org/p/chromium/issues/detail?id=95176
https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/PDFOpenParameters.pdf