### PR TITLE
Initial support for ARM64 Native Compilation

### DIFF
--- a/DEPS
+++ b/DEPS
@@ -535,7 +535,7 @@ deps = {
 
   'src/native_client': {
       'url': Var('chromium_git') + '/native_client/src/native_client.git' + '@' + Var('nacl_revision'),
-      'condition': 'checkout_nacl',
+      'condition': 'checkout_nacl and host_cpu != "arm64"',
   },
 
   'src/net/third_party/quiche/src':
@@ -2292,7 +2292,7 @@ hooks = [
     # anywhere from 30 minutes to 4 hours depending on platform to build.
     'name': 'nacltools',
     'pattern': '.',
-    'condition': 'checkout_nacl',
+    'condition': 'checkout_nacl and host_cpu != "arm64"',
     'action': [
         'python',
         'src/build/download_nacl_toolchains.py',
@@ -2376,7 +2376,7 @@ hooks = [
   {
     'name': 'binutils',
     'pattern': 'src/third_party/binutils',
-    'condition': 'host_os == "linux" and host_cpu != "mips64"',
+    'condition': '(host_os == "linux") and (host_cpu != "mips64" and host_cpu != "arm64")',
     'action': [
         'python',
         'src/third_party/binutils/download.py',

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -43,7 +43,12 @@ declare_args() {
   # warnings with known toolchains. Allow overriding this e.g. for Chromium
   # builds on Linux that could use a different version of the compiler.
   # With GCC, warnings in no-Chromium code are always not treated as errors.
-  treat_warnings_as_errors = true
+  if (current_cpu == "arm" || current_cpu == "arm64") {
+       treat_warnings_as_errors = false
+  }
+  else{
+       treat_warnings_as_errors = true
+  }
 
   # Normally, Android builds are lightly optimized, even for debug builds, to
   # keep binary size down. Setting this flag to true disables such optimization


### PR DESCRIPTION
Dear Team,

Added initial support for  native compilation in ARM64 platform. Disabled nacl tools and binutils for arm64, as they are not supported currently in arm64 platform. 

Please suggest if anything needs to be added.

Thanks in advance.

Regards,