### PR TITLE
Add a script to generate a roll log from a Gitiles revision.

### DIFF
--- a/tools/gitiles_log_summary
+++ b/tools/gitiles_log_summary
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+"""Gitiles log summarizer
+
+Given a Gitiles log url, outputs the list of changes in the log in 
+a summarized form for including in a CL description in a convenient way.
+
+Usage:
+
+  $ gitiles_log_summary https://gn.googlesource.com/gn.git/+log/d062e74..74657a6
+
+"""
+
+import argparse
+import json
+import urllib2
+
+
+parser = argparse.ArgumentParser(
+    description=__doc__,
+    formatter_class=argparse.RawDescriptionHelpFormatter)
+parser.add_argument('url')
+
+args = parser.parse_args()
+
+resp = urllib2.urlopen(args.url + '?format=JSON')
+log = json.loads(resp.read()[5:])
+
+lines = ['    %s %s' % (c['commit'][:8], c['message'].splitlines()[0])
+         for c in log['log']]
+print('    %s\n\n%s' % (args.url, '\n'.join(lines)))


### PR DESCRIPTION
NOT FOR LANDING.

This script can be used to generate a list of one-line revision
summaries from a gitiles URL.

We should not land this directly, but rather should build on this
to create a properly script for rolling GN.