### PR TITLE
Added missing avif dependency in .gitignore

### DIFF
--- a/third_party/.gitignore
+++ b/third_party/.gitignore
@@ -39,6 +39,7 @@
 /arcore-android-sdk/test-apks/arcore/*.apk
 /asan
 /auto/src
+/avif/libavif
 /bazel/desugar/Desugar.jar
 /bison
 /boringssl/src


### PR DESCRIPTION
Few users found it difficult without this.
It fixes the issues like as shown in attachment 
![PrintScreen_06_10](https://user-images.githubusercontent.com/31558638/66273264-021e8500-e890-11e9-9ef6-e78f18a0d5db.png)
