### PR TITLE
Update smil_time.h

### DIFF
--- a/third_party/blink/renderer/core/svg/animation/smil_time.h
+++ b/third_party/blink/renderer/core/svg/animation/smil_time.h
@@ -27,6 +27,7 @@
 #define THIRD_PARTY_BLINK_RENDERER_CORE_SVG_ANIMATION_SMIL_TIME_H_
 
 #include <ostream>
+#include <algorithm>
 
 #include "base/time/time.h"
 #include "third_party/blink/renderer/platform/wtf/allocator/allocator.h"


### PR DESCRIPTION
Not including "algorithm" lead to compiler errors on Windows:
no member named 'min' in namespace 'std'

![algorithm_include](https://user-images.githubusercontent.com/16350339/68095316-a48a5200-fea8-11e9-82ef-bcfb919cda41.png)
