### PR TITLE
Issue 515127: Fix issue where ChromeVox Classic reads contents of "noscript" element

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -28,6 +28,7 @@ Adam Yi <i@adamyi.com>
 Addanki Gandhi Kishor <kishor.ag@samsung.com>
 Adenilson Cavalcanti <a.cavalcanti@samsung.com>
 Aditya Bhargava <heuristicist@gmail.com>
+Adrian D. Alvarez <adrian@adriandalvarez.com>
 Adrian Belgun <adrian.belgun@intel.com>
 Ahmet Emir Ercin <ahmetemiremir@gmail.com>
 Ajay Berwal <a.berwal@samsung.com>

--- a/ui/accessibility/extensions/chromevoxclassic/chromevox/injected/active_indicator.js
+++ b/ui/accessibility/extensions/chromevoxclassic/chromevox/injected/active_indicator.js
@@ -198,6 +198,9 @@ cvox.ActiveIndicator.STYLE =
     '   0% {opacity: 1.0}' +
     '  50% {opacity: 0.5}' +
     ' 100% {opacity: 1.0}' +
+    '}' +
+    'noscript {' +
+    '  display: none;' +
     '}';
 
 /**


### PR DESCRIPTION
Per the html5 spec on the `noscript` element:
The `noscript` element represents nothing if scripting is enabled, and represents its children if scripting is disabled. <https://www.w3.org/TR/html50/scripting-1.html#the-noscript-element>

As pointed out in [crbug.com/515127](https://bugs.chromium.org/p/chromium/issues/detail?id=515127), ChromeVox Classic would read the content of the `noscript` element which is NOT expected when scripting is enabled as it should represent nothing.

ChromeVox Classic injects CSS for the active indicator styles, this commit makes content within `<noscript>` inaccessible to ChromeVox Classic via `display: none`. Due to these styles being injected via JavaScript, this allows for the content within `noscript` to render & display to a user when JavaScript is disabled.

Bug: 515127