### PR TITLE
Added Roboto Fallback In Flags UI

### DIFF
--- a/components/flags_ui/resources/flags.css
+++ b/components/flags_ui/resources/flags.css
@@ -69,7 +69,7 @@ body {
   color: var(--primary-color);
   display: flex;
   flex-direction: column;
-  font-family: Roboto;
+  font-family: Roboto, sans-serif;
   font-size: 0.8125em;
   /* Force the vertical scrollbar to always be displayed, to avoid UI jumps. */
   height: 100vh;


### PR DESCRIPTION
I added a sans-serif fallback, in case Roboto doesn't load - this is more prevalent in projects that use Chromium but do not use Roboto. This way, the font family will default to a sans-serif font, rather than a serif font.