### PR TITLE
Create app_locale_settings_kab.xtb

### DIFF
--- a/ui/strings/translations/app_locale_settings_kab.xtb
+++ b/ui/strings/translations/app_locale_settings_kab.xtb
@@ -1,0 +1,4 @@
+<?xml version="1.0" ?>
+<!DOCTYPE translationbundle>
+<translationbundle lang="kab">
+</translationbundle>


### PR DESCRIPTION
add kabyle locale
Unicode and ISO 639 code: kab
Native name is : Taqbaylit
Kabyle is latin-based system.
An ltr language (left ti right)