### PR TITLE
Allow offline Dino game to read W, S controls

### DIFF
--- a/components/neterror/resources/offline.js
+++ b/components/neterror/resources/offline.js
@@ -212,8 +212,8 @@ Runner.sounds = {
  * @enum {Object}
  */
 Runner.keycodes = {
-  JUMP: {'38': 1, '32': 1},  // Up, spacebar
-  DUCK: {'40': 1},  // Down
+  JUMP: {'38': 1, '32': 1, '87': 1},  // Up, Spacebar, W
+  DUCK: {'40': 1, '83': 1},  // Down, S 
   RESTART: {'13': 1}  // Enter
 };
 


### PR DESCRIPTION
This Would allow the Offline "Dino Runner" game able to check for WASD controls. W for jumping, and S for ducking.