### PR TITLE
Media is not resuming playback on window's focus/visibilitychange event

### DIFF
--- a/media/filters/pipeline_controller.cc
+++ b/media/filters/pipeline_controller.cc
@@ -96,6 +96,12 @@ void PipelineController::Suspend() {
 void PipelineController::Resume() {
   DCHECK(thread_checker_.CalledOnValidThread());
   pending_suspend_ = false;
+
+  if(state_ == State::SWITCHING_TRACKS) {
+    defer_playback_resume_ = true;
+    return;
+  }
+
   if (state_ == State::SUSPENDING || state_ == State::SUSPENDED) {
     pending_resume_ = true;
     Dispatch();
@@ -437,7 +443,13 @@ void PipelineController::FireOnTrackChangeCompleteForTesting(State set_to) {
 void PipelineController::OnTrackChangeComplete(State previous_state) {
   DCHECK(thread_checker_.CalledOnValidThread());
 
-  if (state_ == State::SWITCHING_TRACKS)
+  if(defer_playback_resume_) {
+    state_ = State::SUSPENDED;
+    defer_playback_resume_ = false;
+    Resume();
+    return;
+  }
+  else if (state_ == State::SWITCHING_TRACKS)
     state_ = previous_state;
 
   // Other track changed or seek/suspend/resume, etc may be waiting.

--- a/media/filters/pipeline_controller.cc
+++ b/media/filters/pipeline_controller.cc
@@ -97,7 +97,7 @@ void PipelineController::Resume() {
   DCHECK(thread_checker_.CalledOnValidThread());
   pending_suspend_ = false;
 
-  if(state_ == State::SWITCHING_TRACKS) {
+  if (state_ == State::SWITCHING_TRACKS) {
     defer_playback_resume_ = true;
     return;
   }
@@ -443,7 +443,7 @@ void PipelineController::FireOnTrackChangeCompleteForTesting(State set_to) {
 void PipelineController::OnTrackChangeComplete(State previous_state) {
   DCHECK(thread_checker_.CalledOnValidThread());
 
-  if(defer_playback_resume_) {
+  if (defer_playback_resume_) {
     state_ = State::SUSPENDED;
     defer_playback_resume_ = false;
     Resume();

--- a/media/filters/pipeline_controller.h
+++ b/media/filters/pipeline_controller.h
@@ -220,6 +220,15 @@ class MEDIA_EXPORT PipelineController {
   std::vector<MediaTrack::Id> pending_audio_track_change_ids_;
   base::Optional<MediaTrack::Id> pending_video_track_change_id_;
 
+  // Defer playback resume basing on this flag.
+  // In some corner case when pausing a video on blur/visibilitychange
+  // event and then resuming a video on a tab focus/visibilitychange
+  // event there may be a race condition between
+  // changing video tracks (state: 5) and resuming playback (state: 8).
+  // Because of that the new "RESUMING" state is not assigned and a video
+  // is not starting when a tab with the video is again in focus.
+  bool defer_playback_resume_ = false;
+
   // Set to true during Start(). Indicates that |seeked_cb_| must be fired once
   // we've completed startup.
   bool pending_startup_ = false;

--- a/media/filters/pipeline_controller_unittest.cc
+++ b/media/filters/pipeline_controller_unittest.cc
@@ -535,4 +535,17 @@ TEST_F(PipelineControllerTest, SuspendDuringAudioTrackChange) {
   EXPECT_FALSE(was_resumed_);
 }
 
+TEST_F(PipelineControllerTest, ResumePlaybackDuringSwitchingTracksState) {
+  Complete(StartPipeline());
+  Complete(SuspendPipeline());
+  EXPECT_CALL(*pipeline_, OnSelectedVideoTrackChanged(_, _)).Times(1);
+  EXPECT_CALL(*pipeline_, GetMediaTime()).Times(1);
+  EXPECT_CALL(*pipeline_, OnResume(_, _)).Times(1);
+
+  pipeline_controller_.OnSelectedVideoTrackChanged({});
+  pipeline_controller_.Resume();
+  pipeline_controller_.FireOnTrackChangeCompleteForTesting(
+      PipelineController::State::PLAYING);
+}
+
 }  // namespace media


### PR DESCRIPTION
I have found a rare issue with the resuming video playback logic, to be specific, for some reason during resuming playback on 'window.focus' event after some time (the same with visibilitychange) on some videos, the PipelineController::OnSelectedVideoTrackChanged() event is called almost in the same time when PipelineController::Resume() is called (pipeline_controller.cc source file). The effect is that we are in 'State::SWITCHING_TRACKS' state, and being in this state we are calling PipelineController::Resume() which will have no effect (some race condition).
I am adding this PR with a fix and I will add a chromiumbugs link to this PR later, where you will find some more information and reproduction steps.