### PR TITLE
Set new param for screencastFrame

### DIFF
--- a/content/browser/devtools/protocol/page_handler.cc
+++ b/content/browser/devtools/protocol/page_handler.cc
@@ -75,9 +75,9 @@ constexpr const char* kMhtml = "mhtml";
 constexpr const char* kPng = "png";
 constexpr const char* kJpeg = "jpeg";
 constexpr int kDefaultScreenshotQuality = 80;
-constexpr int kFrameRetryDelayMs = 100;
+constexpr int kFrameRetryDelayMs = 20;
 constexpr int kCaptureRetryLimit = 2;
-constexpr int kMaxScreencastFramesInFlight = 2;
+constexpr int kMaxScreencastFramesInFlight = 10;
 
 Binary EncodeImage(const gfx::Image& image,
                    const std::string& format,


### PR DESCRIPTION
These options solve the problem of creating more frequent screenshots.
More details:
[https://github.com/puppeteer/puppeteer/issues/478](url)

Additionally.
Previous parameters are not relevant for the current time and are outdated