### PR TITLE
Fix broken link in README.md

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -575,6 +575,7 @@ Kihwang Kim <pwangkk@gmail.com>
 Kim Christensen <kimworking@gmail.com>
 Kimberly Hunter <kimberhu@amazon.com>
 Kingshuk Jana <kingshuk.j@samsung.com>
+Kinshuk Dua <kinshukduaexam@gmail.com>
 Kirill Bobyrev <kirillbobyrev@gmail.com>
 Kirill Ovchinnikov <kirill.ovchinn@gmail.com>
 Klemen Forstnerič <klemen.forstneric@gmail.com>

--- a/docs/README.md
+++ b/docs/README.md
@@ -159,7 +159,7 @@ used when committed.
 
 ### Testing
 *   [Running and Debugging Web Tests](testing/web_tests.md)
-*   [On disabling tests](testing/disabling_tests.md)
+*   [On Disabling Tests](testing/on_disabling_tests.md)
 *   [Writing Web Tests](testing/writing_web_tests.md) - Web Tests using
     `content_shell`
 *   [Web Test Expectations and Baselines](testing/web_test_expectations.md) -

--- a/docs/testing/on_disabling_tests.md
+++ b/docs/testing/on_disabling_tests.md
@@ -1,4 +1,4 @@
-# On disabling tests
+# On Disabling Tests
 
 Sometimes you don't want to run a test that you've written (or that
 you've imported, like conformance tests).


### PR DESCRIPTION
Fix broken link for file 'on_disabling_tests.md'. 
In commit 78557c5ac69a2560d4f2dbb5bb5f5d2c14a80085 a new file 'docs/testing/on_disabling_tests.md' was added and it was referenced in the 'docs/README.md' file as 'disabling_tests.md' instead of 'on_disabling_tests.md' leading to a 404 error when you try to click on the link. Also capitalized the words 'on' and 'tests' to be consistent with the rest of the README.