### PR TITLE
Update desktop.template (Linux) to include MHTML support

### DIFF
--- a/chrome/installer/linux/common/desktop.template
+++ b/chrome/installer/linux/common/desktop.template
@@ -111,7 +111,7 @@ Terminal=false
 Icon=@@PACKAGE@@
 Type=Application
 Categories=Network;WebBrowser;
-MimeType=application/pdf;application/rdf+xml;application/rss+xml;application/xhtml+xml;application/xhtml_xml;application/xml;image/gif;image/jpeg;image/png;image/webp;text/html;text/xml;x-scheme-handler/ftp;x-scheme-handler/http;x-scheme-handler/https;
+MimeType=application/pdf;application/rdf+xml;application/rss+xml;application/xhtml+xml;application/xhtml_xml;application/xml;image/gif;image/jpeg;image/png;image/webp;text/html;text/xml;message/rfc822;application/x-mimearchive;x-scheme-handler/ftp;x-scheme-handler/http;x-scheme-handler/https;
 Actions=new-window;new-private-window;
 
 [Desktop Action new-window]


### PR DESCRIPTION
Added ```message/rfc822``` because that is what the ```file``` command uses.
Added ```application/x-mimearchive``` because that is what GNOME uses.