### PR TITLE
Revert "GCC: Use GCC pragma instead of clang"

### DIFF
--- a/third_party/blink/renderer/platform/heap/finalizer_traits.h
+++ b/third_party/blink/renderer/platform/heap/finalizer_traits.h
@@ -43,10 +43,10 @@ struct FinalizerTraitImpl<T, true> {
 // an object's base class has a virtual destructor. In case there is no virtual
 // destructor present, the object is always finalized through its leaf type. In
 // other words: there is no finalization through a base pointer.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdelete-non-virtual-dtor"
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdelete-non-abstract-non-virtual-dtor"
       static_cast<T*>(obj)->~T();
-#pragma GCC diagnostic pop
+#pragma clang diagnostic pop
     }
   };
   using FinalizeImpl =


### PR DESCRIPTION
This reverts commit 6ee9c4028ee5aa5839f9dcdd822196f30f4932b0.