### PR TITLE
Update mac build.md instructions

### DIFF
--- a/docs/mac_build_instructions.md
+++ b/docs/mac_build_instructions.md
@@ -32,7 +32,7 @@ Are you a Google employee? See
 Clone the `depot_tools` repository:
 
 ```shell
-$ git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git
+$ git clone https://chromium.googlesource.com/chromium/tools/depot_tools
 ```
 
 Add `depot_tools` to the end of your PATH (you will probably want to put this in
@@ -49,7 +49,7 @@ $ export PATH="$PATH:/path/to/depot_tools"
 Ensure that unicode filenames aren't mangled by HFS:
 
 ```shell
-$ git config --global core.precomposeUnicode true
+$ git config --global core.precomposeunicode true
 ```
 
 In System Preferences, check that "Energy Saver" -> "Power Adapter" ->


### PR DESCRIPTION
When cloning the depot_tools, it only worked for me if I didn't have the .git at the end of the clone. And for the 'git config' command concerning the end lines, the command only worked for me if it was a lowercase 'u'