### PR TITLE
Fix GSettingsSchema lookup

### DIFF
--- a/net/proxy_resolution/proxy_config_service_linux.cc
+++ b/net/proxy_resolution/proxy_config_service_linux.cc
@@ -281,7 +281,7 @@ class SettingGetterImplGSettings
     DCHECK(!task_runner_.get());
 
     if (!g_settings_schema_source_lookup(g_settings_schema_source_get_default(),
-                                         kProxyGSettingsSchema, FALSE) ||
+                                         kProxyGSettingsSchema, TRUE) ||
         !(client_ = g_settings_new(kProxyGSettingsSchema))) {
       // It's not clear whether/when this can return NULL.
       LOG(ERROR) << "Unable to create a gsettings client";
@@ -493,7 +493,7 @@ bool SettingGetterImplGSettings::CheckVersion(
 
   GSettings* client = nullptr;
   if (g_settings_schema_source_lookup(g_settings_schema_source_get_default(),
-                                      kProxyGSettingsSchema, FALSE)) {
+                                      kProxyGSettingsSchema, TRUE)) {
     client = g_settings_new(kProxyGSettingsSchema);
   }
   if (!client) {


### PR DESCRIPTION
Current proxy detection using GSettings does not work reliable. This is caused
by using non-recursive schema source lookup for the default schema source.

g_settings_schema_source_get_default() can contain multiple schema sources
from different directories and that's why the API recommends to do all lookups
recusively.

Change all g_settings_schema_source_lookup() calls to do a recursive lookup.