### PR TITLE
docs(linux): fix collocation error

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -318,6 +318,7 @@ Dongyu Lin <l2d4y3@gmail.com>
 Donna Wu <donna.wu@intel.com>
 Douglas F. Turner <doug.turner@gmail.com>
 Dustin Doloff <doloffd@amazon.com>
+DigitalGreyHat <me@opencode.me>
 Ebrahim Byagowi <ebrahim@gnu.org>
 Ebrahim Byagowi <ebraminio@gmail.com>
 Eden Wang <nedenwang@tencent.com>

--- a/docs/README.md
+++ b/docs/README.md
@@ -406,7 +406,7 @@ used when committed.
 
 ### Speed
 *   [Chrome Speed](speed/README.md) - Documentation for performance measurements and regressions in Chrome.
-*   [Chrome Speed Metrics](speed_metrics/README.md) - Documentation about user experience metrics in the web and their JavaScript APIs.
+*   [Chrome Speed Metrics](speed_metrics/README.md) - Documentation about user experience metrics on the web and their JavaScript APIs.
 
 ### Probably Obsolete
 *   [TPM Quick Reference](tpm_quick_ref.md) - Trusted Platform Module notes.


### PR DESCRIPTION
The usual collocation for "on the web" is "on", not "in".