### PR TITLE
Add linkText property to extension chrome.contextMenus.OnClickData

### DIFF
--- a/chrome/browser/extensions/menu_manager.cc
+++ b/chrome/browser/extensions/menu_manager.cc
@@ -678,6 +678,8 @@ void MenuManager::ExecuteCommand(content::BrowserContext* context,
   AddURLProperty(properties, "pageUrl", params.page_url);
   AddURLProperty(properties, "frameUrl", params.frame_url);
 
+  if (params.link_text.length() > 0)
+    properties.SetStringKey("linkText", params.link_text);
   if (params.selection_text.length() > 0)
     properties.SetStringKey("selectionText", params.selection_text);
 

--- a/chrome/common/extensions/api/context_menus.json
+++ b/chrome/common/extensions/api/context_menus.json
@@ -75,6 +75,11 @@
             "optional": true,
             "description": " The <a href='webNavigation#frame_ids'>ID of the frame</a> of the element where the context menu was clicked, if it was in a frame."
           },
+          "linkText": {
+            "type": "string",
+            "optional": true,
+            "description": "If the element is a link, the text for the link. May be an empty string if the contents of the link are an image."
+          },
           "selectionText": {
             "type": "string",
             "optional": true,


### PR DESCRIPTION
Please see [\[Feature request\] Add linkText property to extension chrome.contextMenus.OnClickData](https://groups.google.com/a/chromium.org/g/chromium-extensions/c/KQj0cHOpMK4) for background.