### PR TITLE
Fix touchpad history navigation in Linux and kinetic scrolling in Wayland

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -309,6 +309,7 @@ Dmitry Sokolov <dimanne@gmail.com>
 Dominic Farolino <domfarolino@gmail.com>
 Dominic Jodoin <dominic.jodoin@gmail.com>
 Dominik Röttsches <dominik.rottsches@intel.com>
+Dominik Schütz <do.sch.dev@gmail.com>
 Don Woodward <woodward@adobe.com>
 Donghee Na <corona10@gmail.com>
 Dong-hee Na <donghee.na92@gmail.com>

--- a/content/public/common/content_features.cc
+++ b/content/public/common/content_features.cc
@@ -991,10 +991,10 @@ const base::Feature kTouchpadAsyncPinchEvents{"TouchpadAsyncPinchEvents",
                                               base::FEATURE_ENABLED_BY_DEFAULT};
 
 // Allows swipe left/right from touchpad change browser navigation. Currently
-// only enabled by default on CrOS, LaCrOS and Windows.
+// only enabled by default on CrOS, LaCrOS, Windows and Linux.
 const base::Feature kTouchpadOverscrollHistoryNavigation {
   "TouchpadOverscrollHistoryNavigation",
-#if BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_WIN)
+#if BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_WIN) || BUILDFLAG(IS_LINUX)
       base::FEATURE_ENABLED_BY_DEFAULT
 #else
       base::FEATURE_DISABLED_BY_DEFAULT

--- a/ui/events/x/x11_event_translation.cc
+++ b/ui/events/x/x11_event_translation.cc
@@ -188,6 +188,16 @@ std::unique_ptr<ScrollEvent> CreateScrollEvent(EventType type,
     GetFlingDataFromXEvent(xev, &x_offset, &y_offset, &x_offset_ordinal,
                            &y_offset_ordinal, nullptr);
   }
+#if BUILDFLAG(IS_LINUX)
+  // When lifting up fingers x_offset and y_offset both have the value 0
+  // If this is the case ET_SCROLL_FLING_START needs to be emitted, in order to
+  // trigger touchpad overscroll navigation gesture.
+  // x_offset and y_offset should not be manipulated, however, since some X11
+  // drivers such as synaptics simulate the fling themselves
+  if (!x_offset && !y_offset) {
+    type = ET_SCROLL_FLING_START;
+  }
+#endif
   auto event = std::make_unique<ScrollEvent>(
       type, EventLocationFromXEvent(xev), EventTimeFromXEvent(xev),
       EventFlagsFromXEvent(xev), x_offset, y_offset, x_offset_ordinal,
@@ -197,7 +207,8 @@ std::unique_ptr<ScrollEvent> CreateScrollEvent(EventType type,
   // We need to filter zero scroll offset here. Because MouseWheelEventQueue
   // assumes we'll never get a zero scroll offset event and we need delta to
   // determine which element to scroll on phaseBegan.
-  return (event->x_offset() != 0.0 || event->y_offset() != 0.0)
+  return (event->x_offset() != 0.0 || event->y_offset() != 0.0 ||
+          event->type() == ET_SCROLL_FLING_START)
              ? std::move(event)
              : nullptr;
 }

--- a/ui/ozone/platform/wayland/host/wayland_event_source.cc
+++ b/ui/ozone/platform/wayland/host/wayland_event_source.cc
@@ -330,12 +330,6 @@ void WaylandEventSource::OnPointerFrameEvent() {
 
   int flags = pointer_flags_ | keyboard_modifiers_;
 
-  static constexpr bool supports_trackpad_kinetic_scrolling =
-#if BUILDFLAG(IS_CHROMEOS_LACROS)
-      true;
-#else
-      false;
-#endif
   auto* target = current_pointer_frame_.target;
   if (!window_manager_->IsWindowValid(target))
     return;
@@ -343,15 +337,24 @@ void WaylandEventSource::OnPointerFrameEvent() {
   // Dispatch Fling event if pointer.axis_stop is notified and the recent
   // pointer.axis events meets the criteria to start fling scroll.
   if (current_pointer_frame_.dx == 0 && current_pointer_frame_.dy == 0 &&
-      current_pointer_frame_.is_axis_stop &&
-      supports_trackpad_kinetic_scrolling) {
+      current_pointer_frame_.is_axis_stop) {
     gfx::Vector2dF initial_velocity = ComputeFlingVelocity();
     float vx = initial_velocity.x();
     float vy = initial_velocity.y();
+#if !BUILDFLAG(IS_LINUX)
     ScrollEvent event(
         vx == 0 && vy == 0 ? ET_SCROLL_FLING_CANCEL : ET_SCROLL_FLING_START,
         pointer_location_, pointer_location_, now, flags, vx, vy, vx, vy,
         kGestureScrollFingerCount);
+#else
+    // ET_SCROLL_FLING_CANCEL is not triggered according to the Wayland
+    // protocol in the exo implementation. Therefore, it is not emitted on
+    // Linux
+    ScrollEvent event(ET_SCROLL_FLING_START, pointer_location_,
+                      pointer_location_, now, flags, vx, vy, vx, vy,
+                      kGestureScrollFingerCount);
+    is_fling_active_ = true;
+#endif
     SetTargetAndDispatchEvent(&event, target);
     recent_pointer_frames_.clear();
   } else if (current_pointer_frame_.axis_source) {
@@ -366,6 +369,17 @@ void WaylandEventSource::OnPointerFrameEvent() {
                    WL_POINTER_AXIS_SOURCE_FINGER ||
                *current_pointer_frame_.axis_source ==
                    WL_POINTER_AXIS_SOURCE_CONTINUOUS) {
+#if BUILDFLAG(IS_LINUX)
+      // Fling will be stopped if a new scroll event is received.
+      // This matches the behaviour of GTK and Firefox
+      if (is_fling_active_) {
+        is_fling_active_ = false;
+        ScrollEvent event(ET_SCROLL_FLING_CANCEL, pointer_location_,
+                          pointer_location_, now, flags, 0, 0, 0, 0,
+                          kGestureScrollFingerCount);
+        DispatchEvent(&event);
+      }
+#endif
       ScrollEvent event(ET_SCROLL, pointer_location_, pointer_location_,
                         EventTimeForNow(), flags, current_pointer_frame_.dx,
                         current_pointer_frame_.dy, current_pointer_frame_.dx,

--- a/ui/ozone/platform/wayland/host/wayland_event_source.cc
+++ b/ui/ozone/platform/wayland/host/wayland_event_source.cc
@@ -88,7 +88,10 @@ void SetRootLocation(LocatedEvent* event) {
 constexpr int kGestureScrollFingerCount = 2;
 
 // Maximum size of the stored recent pointer frame information.
-constexpr int kRecentPointerFrameMaxSize = 20;
+constexpr int kRecentPointerFrameMaxSize = 3;
+
+// Maximum time delta between last scroll event and lifting of fingers
+constexpr int kFlingStartTimeoutMs = 200;
 
 }  // namespace
 
@@ -722,29 +725,64 @@ bool WaylandEventSource::ShouldUnsetTouchFocus(WaylandWindow* win,
 }
 
 gfx::Vector2dF WaylandEventSource::ComputeFlingVelocity() {
-  // Return average velocity in the last 200ms.
-  // TODO(fukino): Make the formula similar to libgestures's
-  // RegressScrollVelocity(). crbug.com/1129263.
-  base::TimeDelta dt;
-  float dx = 0.0f;
-  float dy = 0.0f;
-  for (auto& frame : recent_pointer_frames_) {
-    if (frame.axis_source &&
-        *frame.axis_source != WL_POINTER_AXIS_SOURCE_FINGER) {
-      break;
-    }
-    if (frame.dx == 0 && frame.dy == 0)
-      break;
-    if (dt + frame.dt > base::Milliseconds(200))
-      break;
+  struct RegressionSums {
+    float tt_;  // Cumulative sum of t^2.
+    float t_;   // Cumulative sum of t.
+    float tx_;  // Cumulative sum of t * x.
+    float ty_;  // Cumulative sum of t * y.
+    float x_;   // Cumulative sum of x.
+    float y_;   // Cumulative sum of y.
+  };
 
-    dx += frame.dx;
-    dy += frame.dy;
-    dt += frame.dt;
+  const size_t count = recent_pointer_frames_.size();
+
+  if (count == 0) {
+    return gfx::Vector2dF();
   }
-  float dt_inv = 1.0f / dt.InSecondsF();
-  return dt.is_zero() ? gfx::Vector2dF()
-                      : gfx::Vector2dF(dx * dt_inv, dy * dt_inv);
+
+  // Prevents small jumps if someone scrolls fast, immediately stops scrolling
+  // and then waits a little before lifting fingers from touchpad
+  if (current_pointer_frame_.dt > base::Milliseconds(kFlingStartTimeoutMs)) {
+    return gfx::Vector2dF();
+  }
+
+  if (count == 1) {
+    const auto& pointer_frame = recent_pointer_frames_.front();
+    const float dt =
+        pointer_frame.dt.InSecondsF() + current_pointer_frame_.dt.InSecondsF();
+    return gfx::Vector2dF(pointer_frame.dx * dt, pointer_frame.dy * dt);
+  }
+
+  RegressionSums sums = {0, 0, 0, 0, 0, 0};
+
+  float time = current_pointer_frame_.dt.InSecondsF();
+  float x_coord = 0;
+  float y_coord = 0;
+
+  // Formula matches libgestures's RegressScrollVelocity()
+  for (const auto& frame : recent_pointer_frames_) {
+    time += frame.dt.InSecondsF();
+    x_coord += frame.dx;
+    y_coord += frame.dy;
+
+    sums.tt_ += time * time;
+    sums.t_ += time;
+    sums.tx_ += time * x_coord;
+    sums.ty_ += time * y_coord;
+    sums.x_ += x_coord;
+    sums.y_ += y_coord;
+  }
+
+  // Note the regression determinant only depends on the values of t, and should
+  // never be zero so long as (1) count > 1, and (2) dt values are all non-zero
+  const float det = count * sums.tt_ - sums.t_ * sums.t_;
+  if (!det) {
+    return gfx::Vector2dF();
+  }
+
+  const float det_inv = 1.0 / det;
+  return gfx::Vector2dF((count * sums.tx_ - sums.t_ * sums.x_) * det_inv,
+                        (count * sums.ty_ - sums.t_ * sums.y_) * det_inv);
 }
 
 bool WaylandEventSource::SurfaceSubmissionInPixelCoordinates() const {

--- a/ui/ozone/platform/wayland/host/wayland_event_source.h
+++ b/ui/ozone/platform/wayland/host/wayland_event_source.h
@@ -260,6 +260,11 @@ class WaylandEventSource : public PlatformEventSource,
   // wl_touch::frame event.
   std::deque<std::unique_ptr<TouchFrame>> touch_frames_;
 
+#if BUILDFLAG(IS_LINUX)
+  // Status of fling.
+  bool is_fling_active_ = false;
+#endif
+
   // Map that keeps track of the current touch points, associating touch IDs to
   // to the surface/location where they happened.
   struct TouchPoint;


### PR DESCRIPTION
For at least 6 years, the touchpad gestures to go forward and backward in the browser history have not worked in Linux. I analyzed and fixed the problem. The kinetic scrolling in Wayland was also fixed. In the source code, kinetic scrolling is referred to as "fling".

The following bugs are fixed by this pull request:
[763791](https://crbug.com/763791)
[1315996](https://crbug.com/1315996)
[1129263](https://crbug.com/1129263)

However, the changes should first be tested by someone in Chrome OS. I can't do this myself because I don't have the appropriate hardware.