### PR TITLE
Group directories separately from files in the file selector dialog

### DIFF
--- a/chrome/browser/file_select_helper.cc
+++ b/chrome/browser/file_select_helper.cc
@@ -240,7 +240,7 @@ void FileSelectHelper::StartNewEnumeration(const base::FilePath& path) {
   base_dir_ = path;
   auto entry = std::make_unique<ActiveDirectoryEnumeration>(path);
   entry->lister_ = base::WrapUnique(new net::DirectoryLister(
-      path, net::DirectoryLister::NO_SORT_RECURSIVE, this));
+      path, net::DirectoryLister::ALPHA_DIRS_FIRST, this));
   entry->lister_->Start();
   directory_enumeration_ = std::move(entry);
 }


### PR DESCRIPTION
The file selector dialog is unwieldy when browsing a directory with many file and directories.  For file navigation it's desirable to group directories separate from files.  I opened an issue here for Brave but the problem is upstream in chromium: https://github.com/brave/brave-browser/issues/25884

Note that comments in directory_lister::SortData() suggest future work that the sort should be removed and done from JS.  This seems like an improvement in usability for the time being.