### PR TITLE
win: fix can not find primary monitor crash

### DIFF
--- a/ui/display/win/screen_win.cc
+++ b/ui/display/win/screen_win.cc
@@ -367,7 +367,9 @@ std::vector<ScreenWinDisplay> DisplayInfosToScreenWinDisplays(
       display_infos_remaining, [](const internal::DisplayInfo& display_info) {
         return display_info.screen_rect().origin().IsOrigin();
       });
-  DCHECK(primary_display_iter != display_infos_remaining.end());
+  if (primary_display_iter == display_infos_remaining.end()) {
+    return {};
+  }
 
   // Build the tree and determine DisplayPlacements along the way.
   DisplayLayoutBuilder builder(primary_display_iter->id());


### PR DESCRIPTION
**Fix** 
https://bugs.chromium.org/p/chromium/issues/detail?id=1436572

**Root Cause:**
Consider this scenario, where you have two screens, called A and B, and B is set as the primary screen. “EnumDisplayMonitors” enumerates the screens, and call "GetMonitorInfo" in the callback function to obtain the screen information. There could be this timing:
1.call "EnumDisplayMonitors"
2.callback the A's screen handle, and get the information about A.
3.unplug the B
4.there will no more callback about B
5.the result of "EnumDisplayMonitors" will only have one screen, and the top left corner is not (0,0)

**Solution:**
Simply return an empty list, because in this scenario, a second "WM_DISPLAYCHANGE" message will come immediately.
**DCHECK does not work in Release mode.**