### PR TITLE
Removed a Bad word / misspelling  from the enum description in Blink/node.h

### DIFF
--- a/third_party/blink/renderer/core/dom/node.h
+++ b/third_party/blink/renderer/core/dom/node.h
@@ -993,8 +993,8 @@ class CORE_EXPORT Node : public EventTarget {
 
  private:
   enum NodeFlags : uint32_t {
-    // Let the NodeTypeMask comes first, so the shit operation can
-    // be eliminated when get NodeType for the reason of performance.
+    // Let the NodeTypeMask come first, so the shift operation can
+    // be eliminated when we want to get NodeType, for the reason of performance.
     // Node type flags. These never change once created.
     kNodeTypeMask = 0xf,
     kIsContainerFlag = 1 << 4,


### PR DESCRIPTION
In the description of enum "NodeFlags" there is a bad word used, its definitely a misspelling. So corrected a minor mistake in this description.
Please let me know if any other change is required.