### PR TITLE
Add semicolons to styles that do not have them

### DIFF
--- a/third_party/blink/renderer/core/html/resources/html.css
+++ b/third_party/blink/renderer/core/html/resources/html.css
@@ -39,7 +39,7 @@ body {
 }
 
 body:-webkit-full-page-media {
-    background-color: rgb(0, 0, 0)
+    background-color: rgb(0, 0, 0);
 }
 
 p {
@@ -51,11 +51,11 @@ p {
 }
 
 div {
-    display: block
+    display: block;
 }
 
 article, aside, footer, header, hgroup, main, nav, section {
-    display: block
+    display: block;
 }
 
 marquee {
@@ -64,7 +64,7 @@ marquee {
 }
 
 address {
-    display: block
+    display: block;
 }
 
 blockquote {
@@ -76,7 +76,7 @@ blockquote {
 }
 
 figcaption {
-    display: block
+    display: block;
 }
 
 figure {
@@ -88,7 +88,7 @@ figure {
 }
 
 q {
-    display: inline
+    display: inline;
 }
 
 q:before {
@@ -102,7 +102,7 @@ q:after {
 center {
     display: block;
     /* special centering to be able to emulate the html4/netscape behaviour */
-    text-align: -webkit-center
+    text-align: -webkit-center;
 }
 
 hr {
@@ -114,11 +114,11 @@ hr {
     margin-inline-start: auto;
     margin-inline-end: auto;
     border-style: inset;
-    border-width: 1px
+    border-width: 1px;
 }
 
 map {
-    display: inline
+    display: inline;
 }
 
 video {
@@ -160,7 +160,7 @@ h1 {
     margin-block-end: 0.67em;
     margin-inline-start: 0;
     margin-inline-end: 0;
-    font-weight: bold
+    font-weight: bold;
 }
 
 :-webkit-any(article,aside,nav,section) h1 {
@@ -200,7 +200,7 @@ h2 {
     margin-block-end: 0.83em;
     margin-inline-start: 0;
     margin-inline-end: 0;
-    font-weight: bold
+    font-weight: bold;
 }
 
 h3 {
@@ -210,7 +210,7 @@ h3 {
     margin-block-end: 1em;
     margin-inline-start: 0;
     margin-inline-end: 0;
-    font-weight: bold
+    font-weight: bold;
 }
 
 h4 {
@@ -219,7 +219,7 @@ h4 {
     margin-block-end: 1.33em;
     margin-inline-start: 0;
     margin-inline-end: 0;
-    font-weight: bold
+    font-weight: bold;
 }
 
 h5 {
@@ -229,7 +229,7 @@ h5 {
     margin-block-end: 1.67em;
     margin-inline-start: 0;
     margin-inline-end: 0;
-    font-weight: bold
+    font-weight: bold;
 }
 
 h6 {
@@ -239,7 +239,7 @@ h6 {
     margin-block-end: 2.33em;
     margin-inline-start: 0;
     margin-inline-end: 0;
-    font-weight: bold
+    font-weight: bold;
 }
 
 /* tables */
@@ -250,25 +250,25 @@ table {
     border-spacing: 2px;
     border-color: gray;
     box-sizing: border-box;
-    text-indent: initial
+    text-indent: initial;
 }
 
 thead {
     display: table-header-group;
     vertical-align: middle;
-    border-color: inherit
+    border-color: inherit;
 }
 
 tbody {
     display: table-row-group;
     vertical-align: middle;
-    border-color: inherit
+    border-color: inherit;
 }
 
 tfoot {
     display: table-footer-group;
     vertical-align: middle;
-    border-color: inherit
+    border-color: inherit;
 }
 
 /* for tables without table section elements (can happen with XHTML or dynamically created tables) */
@@ -277,17 +277,17 @@ table > tr {
 }
 
 col {
-    display: table-column
+    display: table-column;
 }
 
 colgroup {
-    display: table-column-group
+    display: table-column-group;
 }
 
 tr {
     display: table-row;
     vertical-align: inherit;
-    border-color: inherit
+    border-color: inherit;
 }
 
 td, th {
@@ -304,12 +304,12 @@ th:not(table th) {
 
 th {
     font-weight: bold;
-    text-align: -internal-center
+    text-align: -internal-center;
 }
 
 caption {
     display: table-caption;
-    text-align: -webkit-center
+    text-align: -webkit-center;
 }
 
 /* lists */
@@ -321,7 +321,7 @@ ul, menu, dir {
     margin-block-end: 1em;
     margin-inline-start: 0;
     margin-inline-end: 0;
-    padding-inline-start: 40px
+    padding-inline-start: 40px;
 }
 
 ol {
@@ -331,7 +331,7 @@ ol {
     margin-block-end: 1em;
     margin-inline-start: 0;
     margin-inline-end: 0;
-    padding-inline-start: 40px
+    padding-inline-start: 40px;
 }
 
 li {
@@ -340,16 +340,16 @@ li {
 }
 
 ul ul, ol ul {
-    list-style-type: circle
+    list-style-type: circle;
 }
 
 ol ol ul, ol ul ul, ul ol ul, ul ul ul {
-    list-style-type: square
+    list-style-type: square;
 }
 
 dd {
     display: block;
-    margin-inline-start: 40px
+    margin-inline-start: 40px;
 }
 
 dl {
@@ -361,12 +361,12 @@ dl {
 }
 
 dt {
-    display: block
+    display: block;
 }
 
 ol ul, ul ol, ul ul, ol ol {
     margin-block-start: 0;
-    margin-block-end: 0
+    margin-block-end: 0;
 }
 
 /* form elements */
@@ -388,7 +388,7 @@ legend {
     display: block;
     padding-inline-start: 2px;
     padding-inline-end: 2px;
-    border: none
+    border: none;
 }
 
 fieldset {
@@ -769,11 +769,11 @@ select[disabled]>option {
 }
 
 input[type="button" i]:active, input[type="submit" i]:active, input[type="reset" i]:active, input[type="file" i]:active::-webkit-file-upload-button, button:active {
-    border-style: inset
+    border-style: inset;
 }
 
 input[type="button" i]:active:disabled, input[type="submit" i]:active:disabled, input[type="reset" i]:active:disabled, input[type="file" i]:active:disabled::-webkit-file-upload-button, button:active:disabled {
-    border-style: outset
+    border-style: outset;
 }
 
 input:disabled, textarea:disabled {
@@ -839,7 +839,7 @@ input[type="color" i]::-webkit-color-swatch-wrapper {
     box-sizing: border-box;
     -webkit-user-modify: read-only !important;
     width: 100%;
-    height: 100%
+    height: 100%;
 }
 
 input[type="color" i]::-webkit-color-swatch {
@@ -855,7 +855,7 @@ input[type="color" i]::-webkit-color-swatch {
 input[type="color" i][list] {
     appearance: auto;
     inline-size: 94px;
-      block-size: 27px
+      block-size: 27px;
 }
 
 input[type="color" i][list]::-webkit-color-swatch-wrapper {
@@ -1066,21 +1066,21 @@ meter::-webkit-meter-optimum-value {
     block-size: 100%;
     -webkit-user-modify: read-only !important;
     box-sizing: border-box;
-    background: -internal-light-dark(#107c10, #74b374)
+    background: -internal-light-dark(#107c10, #74b374);
 }
 
 meter::-webkit-meter-suboptimum-value {
     block-size: 100%;
     -webkit-user-modify: read-only !important;
     box-sizing: border-box;
-    background: -internal-light-dark(#ffb900, #f2c812)
+    background: -internal-light-dark(#ffb900, #f2c812);
 }
 
 meter::-webkit-meter-even-less-good-value {
     block-size: 100%;
     -webkit-user-modify: read-only !important;
     box-sizing: border-box;
-    background: -internal-light-dark(#d83b01, #e98f6d)
+    background: -internal-light-dark(#d83b01, #e98f6d);
 }
 
 /* progress */
@@ -1120,7 +1120,7 @@ progress::-webkit-progress-value {
 /* inline elements */
 
 u, ins {
-    text-decoration: underline
+    text-decoration: underline;
 }
 
 abbr[title], acronym[title] {
@@ -1128,15 +1128,15 @@ abbr[title], acronym[title] {
 }
 
 strong, b {
-    font-weight: bold
+    font-weight: bold;
 }
 
 i, cite, em, var, address, dfn {
-    font-style: italic
+    font-style: italic;
 }
 
 tt, code, kbd, samp {
-    font-family: monospace
+    font-family: monospace;
 }
 
 pre, xmp, plaintext, listing {
@@ -1152,29 +1152,29 @@ mark {
 }
 
 big {
-    font-size: larger
+    font-size: larger;
 }
 
 small {
-    font-size: smaller
+    font-size: smaller;
 }
 
 s, strike, del {
-    text-decoration: line-through
+    text-decoration: line-through;
 }
 
 sub {
     vertical-align: sub;
-    font-size: smaller
+    font-size: smaller;
 }
 
 sup {
     vertical-align: super;
-    font-size: smaller
+    font-size: smaller;
 }
 
 nobr {
-    white-space: nowrap
+    white-space: nowrap;
 }
 
 /* states */
@@ -1185,19 +1185,19 @@ nobr {
 
 :-internal-spatial-navigation-interest {
     outline: auto 1px -webkit-focus-ring-color !important;
-    box-shadow: none !important
+    box-shadow: none !important;
 }
 
 :focus-visible {
-    outline: auto 1px -webkit-focus-ring-color
+    outline: auto 1px -webkit-focus-ring-color;
 }
 
 html:focus-visible, body:focus-visible {
-    outline: none
+    outline: none;
 }
 
 embed:focus-visible, iframe:focus-visible, object:focus-visible {
-    outline: none
+    outline: none;
 }
 
 input:focus-visible, textarea:focus-visible, select:focus-visible {
@@ -1211,7 +1211,7 @@ input[type="image" i]:focus-visible,
 input[type="reset" i]:focus-visible,
 input[type="submit" i]:focus-visible,
 input[type="file" i]:focus-visible::-webkit-file-upload-button {
-    outline-offset: 0
+    outline-offset: 0;
 }
 
 input[type="checkbox" i]:focus-visible,
@@ -1301,7 +1301,7 @@ a:-webkit-any-link {
 }
 
 a:-webkit-any-link:active {
-    color: -webkit-activelink
+    color: -webkit-activelink;
 }
 
 a:-webkit-any-link:read-write {
@@ -1332,15 +1332,15 @@ ruby > rt {
 /* other elements */
 
 frameset, frame {
-    display: block
+    display: block;
 }
 
 frameset {
-    border-color: inherit
+    border-color: inherit;
 }
 
 iframe {
-    border: 2px inset
+    border: 2px inset;
 }
 
 fencedframe {
@@ -1350,11 +1350,11 @@ fencedframe {
 }
 
 details {
-    display: block
+    display: block;
 }
 
 summary {
-    display: block
+    display: block;
 }
 
 /*


### PR DESCRIPTION
In the file `/third_party/blink/renderer/core/html/resources/html.css` some styles do not have semicolons. I propose to add semicolons to all styles in that file to make it consistent.