### PR TITLE
Fixed latency issue with VideoDecode implementation for H264 and H265 decoders

### DIFF
--- a/media/gpu/h264_decoder.cc
+++ b/media/gpu/h264_decoder.cc
@@ -1476,6 +1476,7 @@ H264Decoder::DecodeResult H264Decoder::Decode() {
       par_res = parser_.AdvanceToNextNALU(curr_nalu_.get());
       if (par_res == H264Parser::kEOStream) {
         CHECK_ACCELERATOR_RESULT(FinishPrevFrameIfPresent());
+        OutputAllRemainingPics();
         return kRanOutOfStreamData;
       } else if (par_res != H264Parser::kOk) {
         SET_ERROR_AND_RETURN();

--- a/media/gpu/h265_decoder.cc
+++ b/media/gpu/h265_decoder.cc
@@ -205,6 +205,7 @@ H265Decoder::DecodeResult H265Decoder::Decode() {
         curr_nalu_.reset();
         // We receive one frame per buffer, so we can output the frame now.
         CHECK_ACCELERATOR_RESULT(FinishPrevFrameIfPresent());
+        OutputAllRemainingPics();
         return kRanOutOfStreamData;
       }
       if (par_res != H265Parser::kOk) {


### PR DESCRIPTION
As detailed in [crbug.com/1462868](https://crbug.com/1462868), this pull request fixes an identified issue in the Chromium implementation of the WebCodecs standard, when dealing with VideoDecoder for H264 and H265 streams. In summary, where a correctly configured H265 stream is provided to Chromium, it is expected that individual frames can be passed to the decode() method of VideoDecoder, and that each frame will progress to being output to the VideoFrameOutputCallback for the decoder without further frames needing to be provided, or flush() needing to be called. In reality, there is 1 frame of latency, where flush() needs to be called, or a subsequent frame submitted for decoding, before Chromium releases the previous frame for output. This makes it impossible to properly display variable rate streams in a predictable and consistent manner.

The cause of this latency is an apparent error in the existing code for the H264 and H265 decoders. As commented in the H265 decoder, the intent is that when the end of the input data stream is reached, any frames pending output are intended to be emitted. In reality, pending frames were only sent for decoding, but the processing step to ensure they were being output was not being run. This code change corrects the issue. Testing steps are given in the bug report.