### PR TITLE
Reverting the kDisableWindows10CustomTitlebar switch removal

### DIFF
--- a/chrome/browser/themes/theme_helper_win.cc
+++ b/chrome/browser/themes/theme_helper_win.cc
@@ -19,5 +19,6 @@ int ThemeHelperWin::GetDefaultDisplayProperty(int id) const {
 
 bool ThemeHelperWin::ShouldUseNativeFrame(
     const CustomThemeSupplier* theme_supplier) const {
-  return true;
+  return !ShouldAlwaysUseSystemTitlebar() ||
+         !HasCustomImage(IDR_THEME_FRAME, theme_supplier);
 }

--- a/chrome/browser/ui/color/win/native_chrome_color_mixer_win.cc
+++ b/chrome/browser/ui/color/win/native_chrome_color_mixer_win.cc
@@ -8,6 +8,7 @@
 #include "base/functional/bind.h"
 #include "base/no_destructor.h"
 #include "base/win/windows_version.h"
+#include "chrome/browser/themes/browser_theme_pack.h"
 #include "chrome/browser/themes/theme_properties.h"
 #include "chrome/browser/ui/color/chrome_color_id.h"
 #include "chrome/browser/win/titlebar_config.h"
@@ -16,7 +17,7 @@
 #include "ui/color/color_id.h"
 #include "ui/color/color_mixer.h"
 #include "ui/color/color_provider.h"
-#include "ui/color/color_provider_key.h"
+#include "ui/color/color_provider_manager.h"
 #include "ui/color/color_provider_utils.h"
 #include "ui/color/color_recipe.h"
 #include "ui/color/color_transform.h"
@@ -38,15 +39,23 @@ class FrameColorHelper {
   ~FrameColorHelper() = default;
 
   void AddNativeChromeColors(ui::ColorMixer& mixer,
-                             const ui::ColorProviderKey& key) const;
+                             const ui::ColorProviderManager::Key& key) const;
   void AddBorderAccentColors(ui::ColorMixer& mixer) const;
 
   static FrameColorHelper* Get();
 
  private:
+  // Returns whether there is a custom image provided for the given id.
+  bool HasCustomImage(int id, const ui::ColorProviderManager::Key& key) const;
+
+  // Returns true if colors from DWM can be used, i.e. this is a native frame
+  // on Windows 8+.
+  bool DwmColorsAllowed(const ui::ColorProviderManager::Key& key) const;
+
   // Returns the Tint for the given |id|. If there is no tint, the identity tint
   // {-1, -1, -1} is returned and won't tint the color on which it is used.
-  color_utils::HSL GetTint(int id, const ui::ColorProviderKey& key) const;
+  color_utils::HSL GetTint(int id,
+                           const ui::ColorProviderManager::Key& key) const;
 
   // Callback executed when the accent color is updated. This re-reads the
   // accent color and updates |dwm_frame_color_| and
@@ -77,9 +86,9 @@ FrameColorHelper::FrameColorHelper() {
 
 void FrameColorHelper::AddNativeChromeColors(
     ui::ColorMixer& mixer,
-    const ui::ColorProviderKey& key) const {
+    const ui::ColorProviderManager::Key& key) const {
   using TP = ThemeProperties;
-  using ColorMode = ui::ColorProviderKey::ColorMode;
+  using ColorMode = ui::ColorProviderManager::ColorMode;
 
   auto get_theme_color = [key](int id) -> absl::optional<SkColor> {
     SkColor theme_color;
@@ -88,72 +97,66 @@ void FrameColorHelper::AddNativeChromeColors(
     return absl::nullopt;
   };
 
-  // When we're custom-drawing the titlebar we want to use either the colors
-  // we calculated in OnDwmKeyUpdated() or the default colors. When we're not
-  // custom-drawing the titlebar we want to match the color Windows actually
-  // uses because some things (like the incognito icon) use this color to
-  // decide whether they should draw in light or dark mode. Incognito colors
-  // should be the same as non-incognito in all cases here.
+  if (DwmColorsAllowed(key)) {
+    // When we're custom-drawing the titlebar we want to use either the colors
+    // we calculated in OnDwmKeyUpdated() or the default colors. When we're not
+    // custom-drawing the titlebar we want to match the color Windows actually
+    // uses because some things (like the incognito icon) use this color to
+    // decide whether they should draw in light or dark mode. Incognito colors
+    // should be the same as non-incognito in all cases here.
 
-  constexpr SkColor kSystemMicaLightFrameColor =
-      SkColorSetRGB(0xE8, 0xE8, 0xE8);
-  constexpr SkColor kSystemMicaDarkFrameColor = SkColorSetRGB(0x20, 0x20, 0x20);
+    constexpr SkColor kSystemSolidLightFrameColor = SK_ColorWHITE;
+    constexpr SkColor kSystemSolidDarkActiveFrameColor = SK_ColorBLACK;
+    constexpr SkColor kSystemSolidDarkInactiveFrameColor =
+        SkColorSetRGB(0x2B, 0x2B, 0x2B);
 
-  absl::optional<ui::ColorTransform> active_frame_transform;
-  if (auto color = get_theme_color(TP::COLOR_FRAME_ACTIVE)) {
-    active_frame_transform = {color.value()};
-  } else if (dwm_frame_color_) {
-    active_frame_transform = {dwm_frame_color_.value()};
-  } else if (ShouldDefaultThemeUseMicaTitlebar()) {
-    active_frame_transform = {key.color_mode == ColorMode::kDark
-                                  ? kSystemMicaDarkFrameColor
-                                  : kSystemMicaLightFrameColor};
-  }
+    constexpr SkColor kSystemMicaLightFrameColor =
+        SkColorSetRGB(0xE8, 0xE8, 0xE8);
+    constexpr SkColor kSystemMicaDarkFrameColor =
+        SkColorSetRGB(0x20, 0x20, 0x20);
 
-  absl::optional<ui::ColorTransform> inactive_frame_transform;
-  if (auto color = get_theme_color(TP::COLOR_FRAME_INACTIVE)) {
-    inactive_frame_transform = {color.value()};
-  } else if (dwm_inactive_frame_color_) {
-    inactive_frame_transform = {dwm_inactive_frame_color_.value()};
-  } else if (dwm_frame_color_) {
-    inactive_frame_transform =
-        ui::HSLShift({dwm_frame_color_.value()},
-                     GetTint(ThemeProperties::TINT_FRAME_INACTIVE, key));
-  } else if (ShouldDefaultThemeUseMicaTitlebar()) {
-    inactive_frame_transform = {key.color_mode == ColorMode::kDark
-                                    ? kSystemMicaDarkFrameColor
-                                    : kSystemMicaLightFrameColor};
-  }
+    if (auto color = get_theme_color(TP::COLOR_FRAME_ACTIVE)) {
+      mixer[ui::kColorFrameActive] = {color.value()};
+    } else if (dwm_frame_color_) {
+      mixer[ui::kColorFrameActive] = {dwm_frame_color_.value()};
+    } else if (ShouldDefaultThemeUseMicaTitlebar() && !key.app_controller) {
+      mixer[ui::kColorFrameActive] = {key.color_mode == ColorMode::kDark
+                                          ? kSystemMicaDarkFrameColor
+                                          : kSystemMicaLightFrameColor};
+    } else if (ShouldAlwaysUseSystemTitlebar()) {
+      mixer[ui::kColorFrameActive] = {key.color_mode == ColorMode::kDark
+                                          ? kSystemSolidDarkActiveFrameColor
+                                          : kSystemSolidLightFrameColor};
+    }
 
-  // If setting custom window frame colors ensure we also update the
-  // corresponding sys header colors. Although this diverges from chrome's
-  // material spec these overrides are necessary to ensure UI assigned to these
-  // color roles can continue to work as expected while respecting platform
-  // frame overrides.
-  if (active_frame_transform) {
-    mixer[ui::kColorFrameActive] = active_frame_transform.value();
-    mixer[ui::kColorSysHeader] = active_frame_transform.value();
-    mixer[ui::kColorSysOnHeaderDivider] =
-        GetColorWithMaxContrast(ui::kColorSysHeader);
-    mixer[ui::kColorSysOnHeaderPrimary] =
-        GetColorWithMaxContrast(ui::kColorSysHeader);
-  }
-  if (inactive_frame_transform) {
-    mixer[ui::kColorFrameInactive] = inactive_frame_transform.value();
-    mixer[ui::kColorSysHeaderInactive] = inactive_frame_transform.value();
-    mixer[ui::kColorSysOnHeaderDividerInactive] =
-        GetColorWithMaxContrast(ui::kColorSysHeaderInactive);
-    mixer[ui::kColorSysOnHeaderPrimaryInactive] =
-        GetColorWithMaxContrast(ui::kColorSysHeaderInactive);
-  }
+    if (auto color = get_theme_color(TP::COLOR_FRAME_INACTIVE)) {
+      mixer[ui::kColorFrameInactive] = {color.value()};
+    } else if (dwm_inactive_frame_color_) {
+      mixer[ui::kColorFrameInactive] = {dwm_inactive_frame_color_.value()};
+    } else if (ShouldDefaultThemeUseMicaTitlebar() && !key.app_controller) {
+      mixer[ui::kColorFrameInactive] = {key.color_mode == ColorMode::kDark
+                                            ? kSystemMicaDarkFrameColor
+                                            : kSystemMicaLightFrameColor};
+    } else if (ShouldAlwaysUseSystemTitlebar()) {
+      mixer[ui::kColorFrameInactive] = {key.color_mode == ColorMode::kDark
+                                            ? kSystemSolidDarkInactiveFrameColor
+                                            : kSystemSolidLightFrameColor};
+    } else if (dwm_frame_color_) {
+      mixer[ui::kColorFrameInactive] =
+          ui::HSLShift({dwm_frame_color_.value()},
+                       GetTint(ThemeProperties::TINT_FRAME_INACTIVE, key));
+    }
 
-  if (ShouldDefaultThemeUseMicaTitlebar() && !key.app_controller) {
-    mixer[kColorNewTabButtonBackgroundFrameActive] = {SK_ColorTRANSPARENT};
-    mixer[kColorNewTabButtonBackgroundFrameInactive] = {SK_ColorTRANSPARENT};
-    mixer[kColorNewTabButtonInkDropFrameActive] =
-        ui::GetColorWithMaxContrast(ui::kColorFrameActive);
-    mixer[kColorNewTabButtonInkDropFrameInactive] =
-        ui::GetColorWithMaxContrast(ui::kColorFrameInactive);
+    if (ShouldDefaultThemeUseMicaTitlebar() && !key.app_controller) {
+      mixer[kColorNewTabButtonBackgroundFrameActive] = {SK_ColorTRANSPARENT};
+      mixer[kColorNewTabButtonInkDropFrameActive] =
+          ui::GetColorWithMaxContrast(ui::kColorFrameActive);
+    }
+  } else {
+    if (auto color = get_theme_color(TP::COLOR_FRAME_ACTIVE))
+      mixer[ui::kColorFrameActive] = {color.value()};
+    if (auto color = get_theme_color(TP::COLOR_FRAME_INACTIVE))
+      mixer[ui::kColorFrameInactive] = {color.value()};
   }
 }
 
@@ -176,17 +179,30 @@ FrameColorHelper* FrameColorHelper::Get() {
   return g_frame_color_helper.get();
 }
 
+bool FrameColorHelper::HasCustomImage(
+    int id,
+    const ui::ColorProviderManager::Key& key) const {
+  return BrowserThemePack::IsPersistentImageID(id) && key.custom_theme &&
+         key.custom_theme->HasCustomImage(id);
+}
+
+bool FrameColorHelper::DwmColorsAllowed(
+    const ui::ColorProviderManager::Key& key) const {
+  return !ShouldAlwaysUseSystemTitlebar() ||
+         !HasCustomImage(IDR_THEME_FRAME, key);
+}
+
 color_utils::HSL FrameColorHelper::GetTint(
     int id,
-    const ui::ColorProviderKey& key) const {
+    const ui::ColorProviderManager::Key& key) const {
   color_utils::HSL hsl;
   if (key.custom_theme && key.custom_theme->GetTint(id, &hsl))
     return hsl;
   // Always pass false for |incognito| here since the ColorProvider is treating
   // incognito mode as dark mode. If this needs to change, that information will
-  // need to propagate into the ColorProviderKey.
+  // need to propagate into the ColorProviderManager::Key.
   return ThemeProperties::GetDefaultTint(
-      id, false, key.color_mode == ui::ColorProviderKey::ColorMode::kDark);
+      id, false, key.color_mode == ui::ColorProviderManager::ColorMode::kDark);
 }
 
 void FrameColorHelper::OnAccentColorUpdated() {
@@ -225,7 +241,7 @@ ui::ColorTransform GetCaptionForegroundColor(
 }  // namespace
 
 void AddNativeChromeColorMixer(ui::ColorProvider* provider,
-                               const ui::ColorProviderKey& key) {
+                               const ui::ColorProviderManager::Key& key) {
   ui::ColorMixer& mixer = provider->AddMixer();
 
   // NOTE: These cases are always handled, even on Win7, in order to ensure the
@@ -257,13 +273,13 @@ void AddNativeChromeColorMixer(ui::ColorProvider* provider,
   mixer[kColorTryChromeForeground] = {SkColorSetA(SK_ColorWHITE, 0xAD)};
   mixer[kColorTryChromeHeaderForeground] = {SK_ColorWHITE};
 
-  if (key.color_mode == ui::ColorProviderKey::ColorMode::kLight) {
+  if (key.color_mode == ui::ColorProviderManager::ColorMode::kLight) {
     mixer[kColorNewTabPageBackground] = {ui::kColorNativeWindow};
     mixer[kColorNewTabPageLink] = {ui::kColorNativeHotlight};
     mixer[kColorNewTabPageText] = {ui::kColorNativeWindowText};
   }
 
-  if (key.contrast_mode != ui::ColorProviderKey::ContrastMode::kHigh) {
+  if (key.contrast_mode != ui::ColorProviderManager::ContrastMode::kHigh) {
     FrameColorHelper::Get()->AddNativeChromeColors(mixer, key);
     return;
   }

--- a/chrome/browser/ui/views/frame/browser_frame_view_win.cc
+++ b/chrome/browser/ui/views/frame/browser_frame_view_win.cc
@@ -33,7 +33,6 @@
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/base/resource/resource_bundle_win.h"
 #include "ui/base/theme_provider.h"
-#include "ui/base/ui_base_features.h"
 #include "ui/base/win/hwnd_metrics.h"
 #include "ui/display/win/dpi.h"
 #include "ui/display/win/screen_win.h"
@@ -71,8 +70,6 @@ base::win::ScopedHICON CreateHICONFromSkBitmapSizedTo(
 constexpr int kMaximizedLeftMargin = 2;
 
 constexpr int kIconTitleSpacing = 5;
-
-constexpr int kCR23TopAreaHeight = 6;
 
 }  // namespace
 
@@ -409,7 +406,7 @@ void BrowserFrameViewWin::ResetWindowControls() {
 void BrowserFrameViewWin::OnThemeChanged() {
   BrowserNonClientFrameView::OnThemeChanged();
   if (!ShouldBrowserCustomDrawTitlebar(browser_view())) {
-    SetSystemMicaTitlebarAttributes();
+    SetSystemTitlebarAttributes();
   }
 }
 
@@ -520,7 +517,7 @@ int BrowserFrameViewWin::FrameTopBorderThicknessPx(bool restored) const {
 
 int BrowserFrameViewWin::TopAreaHeight(bool restored) const {
   if (frame()->IsFullscreen() && !restored) {
-    return features::IsChromeRefresh2023() ? kCR23TopAreaHeight : 0;
+    return 0;
   }
 
   const bool maximized = IsMaximized() && !restored;
@@ -532,10 +529,6 @@ int BrowserFrameViewWin::TopAreaHeight(bool restored) const {
     top += maximized ? TitlebarMaximizedVisualHeight()
                      : caption_button_container_->GetPreferredSize().height();
     return top;
-  }
-
-  if (features::IsChromeRefresh2023()) {
-    return top + kCR23TopAreaHeight;
   }
 
   // In maximized mode, we do not add any additional thickness to the grab
@@ -639,24 +632,26 @@ bool BrowserFrameViewWin::ShouldShowWindowTitle(TitlebarType type) const {
 
 void BrowserFrameViewWin::TabletModeChanged() {
   if (!ShouldBrowserCustomDrawTitlebar(browser_view())) {
-    SetSystemMicaTitlebarAttributes();
+    SetSystemTitlebarAttributes();
   }
 }
 
-void BrowserFrameViewWin::SetSystemMicaTitlebarAttributes() {
-  CHECK(SystemTitlebarCanUseMicaMaterial());
+void BrowserFrameViewWin::SetSystemTitlebarAttributes() {
+  if (SystemTitlebarSupportsDarkMode()) {
+    const BOOL dark_titlebar_enabled = GetNativeTheme()->ShouldUseDarkColors();
+    DwmSetWindowAttribute(views::HWNDForWidget(frame()),
+                          DWMWA_USE_IMMERSIVE_DARK_MODE, &dark_titlebar_enabled,
+                          sizeof(dark_titlebar_enabled));
+  }
 
-  const BOOL dark_titlebar_enabled = GetNativeTheme()->ShouldUseDarkColors();
-  DwmSetWindowAttribute(views::HWNDForWidget(frame()),
-                        DWMWA_USE_IMMERSIVE_DARK_MODE, &dark_titlebar_enabled,
-                        sizeof(dark_titlebar_enabled));
-
-  const DWM_SYSTEMBACKDROP_TYPE dwm_backdrop_type =
-      browser_view()->GetTabStripVisible() ? DWMSBT_TABBEDWINDOW
-                                           : DWMSBT_MAINWINDOW;
-  DwmSetWindowAttribute(views::HWNDForWidget(frame()),
-                        DWMWA_SYSTEMBACKDROP_TYPE, &dwm_backdrop_type,
-                        sizeof(dwm_backdrop_type));
+  if (ShouldBrowserUseMicaTitlebar(browser_view())) {
+    const DWM_SYSTEMBACKDROP_TYPE dwm_backdrop_type =
+        browser_view()->GetTabStripVisible() ? DWMSBT_TABBEDWINDOW
+                                             : DWMSBT_MAINWINDOW;
+    DwmSetWindowAttribute(views::HWNDForWidget(frame()),
+                          DWMWA_SYSTEMBACKDROP_TYPE, &dwm_backdrop_type,
+                          sizeof(dwm_backdrop_type));
+  }
 }
 
 SkColor BrowserFrameViewWin::GetTitlebarColor() const {

--- a/chrome/browser/ui/views/frame/browser_frame_view_win.h
+++ b/chrome/browser/ui/views/frame/browser_frame_view_win.h
@@ -69,11 +69,6 @@ class BrowserFrameViewWin : public BrowserNonClientFrameView,
   bool IsMaximized() const;
   bool IsWebUITabStrip() const;
 
-  // Returns the y coordinate for the top of the frame, which in maximized mode
-  // is the top of the screen and in restored mode is 1 pixel below the top of
-  // the window to leave room for the visual border that Windows draws.
-  int WindowTopY() const;
-
   // Visual height of the titlebar when the window is maximized (i.e. excluding
   // the area above the top of the screen).
   int TitlebarMaximizedVisualHeight() const;
@@ -130,6 +125,11 @@ class BrowserFrameViewWin : public BrowserNonClientFrameView,
   // don't have tabs.
   int TitlebarHeight(bool restored) const;
 
+  // Returns the y coordinate for the top of the frame, which in maximized mode
+  // is the top of the screen and in restored mode is 1 pixel below the top of
+  // the window to leave room for the visual border that Windows draws.
+  int WindowTopY() const;
+
   // Returns the width of the caption buttons region, including visible
   // system-drawn and custom-drawn caption buttons.
   int CaptionButtonsRegionWidth() const;
@@ -145,8 +145,8 @@ class BrowserFrameViewWin : public BrowserNonClientFrameView,
   // Called when the device enters or exits tablet mode.
   void TabletModeChanged();
 
-  // Sets DWM attributes for rendering the system-drawn Mica titlebar.
-  void SetSystemMicaTitlebarAttributes();
+  // Sets DWM attributes for rendering the system-drawn titlebar.
+  void SetSystemTitlebarAttributes();
 
   // Paint various sub-components of this view.
   void PaintTitlebar(gfx::Canvas* canvas) const;

--- a/chrome/browser/win/titlebar_config.cc
+++ b/chrome/browser/win/titlebar_config.cc
@@ -4,26 +4,45 @@
 
 #include "chrome/browser/win/titlebar_config.h"
 
+#include "base/command_line.h"
 #include "base/win/windows_version.h"
 #include "chrome/browser/themes/theme_service.h"
 #include "chrome/browser/themes/theme_service_factory.h"
 #include "chrome/browser/ui/views/frame/browser_view.h"
+#include "chrome/common/chrome_switches.h"
 #include "ui/color/win/accent_color_observer.h"
 #include "ui/native_theme/native_theme.h"
 
+namespace {
 // Allows the titlebar to be drawn by the system using the Mica material
 // on Windows 11, version 22H2 and above.
 BASE_FEATURE(kWindows11MicaTitlebar,
              "Windows11MicaTitlebar",
-             base::FEATURE_DISABLED_BY_DEFAULT);
+             base::FEATURE_ENABLED_BY_DEFAULT);
+}  // namespace
 
 bool ShouldBrowserCustomDrawTitlebar(BrowserView* browser_view) {
-  return !ShouldDefaultThemeUseMicaTitlebar() ||
-         !ThemeServiceFactory::GetForProfile(browser_view->GetProfile())
-              ->UsingSystemTheme() ||
-         (!browser_view->browser()->is_type_normal() &&
-          !browser_view->browser()->is_type_popup() &&
-          !browser_view->browser()->is_type_devtools());
+  return !ShouldAlwaysUseSystemTitlebar() &&
+         !ShouldBrowserUseMicaTitlebar(browser_view);
+}
+
+bool ShouldAlwaysUseSystemTitlebar() {
+  // Cache flag lookup.
+  static const bool custom_titlebar_disabled =
+      base::CommandLine::InitializedForCurrentProcess() &&
+      base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kDisableWindows10CustomTitlebar);
+
+  return custom_titlebar_disabled;
+}
+
+bool ShouldBrowserUseMicaTitlebar(BrowserView* browser_view) {
+  return ShouldDefaultThemeUseMicaTitlebar() &&
+         (browser_view->browser()->is_type_normal() ||
+          browser_view->browser()->is_type_popup() ||
+          browser_view->browser()->is_type_devtools()) &&
+         ThemeServiceFactory::GetForProfile(browser_view->GetProfile())
+             ->UsingSystemTheme();
 }
 
 bool ShouldDefaultThemeUseMicaTitlebar() {
@@ -36,4 +55,8 @@ bool ShouldDefaultThemeUseMicaTitlebar() {
 bool SystemTitlebarCanUseMicaMaterial() {
   return base::win::GetVersion() >= base::win::Version::WIN11_22H2 &&
          base::FeatureList::IsEnabled(kWindows11MicaTitlebar);
+}
+
+bool SystemTitlebarSupportsDarkMode() {
+  return base::win::GetVersion() >= base::win::Version::WIN11;
 }

--- a/chrome/browser/win/titlebar_config.h
+++ b/chrome/browser/win/titlebar_config.h
@@ -9,10 +9,16 @@
 
 class BrowserView;
 
-BASE_DECLARE_FEATURE(kWindows11MicaTitlebar);
-
 // Returns whether we should custom draw the titlebar for a browser window.
 bool ShouldBrowserCustomDrawTitlebar(BrowserView* browser_view);
+
+// Returns whether we should always use the system titlebar, even when a theme
+// is applied.
+bool ShouldAlwaysUseSystemTitlebar();
+
+// Returns whether we should use the Mica titlebar material for a browser
+// window.
+bool ShouldBrowserUseMicaTitlebar(BrowserView* browser_view);
 
 // Returns whether we should use the Mica titlebar in standard browser windows
 // using the default theme.
@@ -21,5 +27,8 @@ bool ShouldDefaultThemeUseMicaTitlebar();
 // Returns whether the system-drawn titlebar can be drawn using the Mica
 // material.
 bool SystemTitlebarCanUseMicaMaterial();
+
+// Returns whether the system-drawn titlebar can be drawn in dark mode.
+bool SystemTitlebarSupportsDarkMode();
 
 #endif  // CHROME_BROWSER_WIN_TITLEBAR_CONFIG_H_

--- a/chrome/common/chrome_switches.cc
+++ b/chrome/common/chrome_switches.cc
@@ -775,6 +775,10 @@ const char kMakeChromeDefault[] = "make-chrome-default";
 #endif  // BUILDFLAG(IS_MAC)
 
 #if BUILDFLAG(IS_WIN)
+// Disables custom-drawing the window titlebar on Windows 10.
+const char kDisableWindows10CustomTitlebar[] =
+    "disable-windows10-custom-titlebar";
+
 // Force-enables the profile shortcut manager. This is needed for tests since
 // they use a custom-user-data-dir which disables this.
 const char kEnableProfileShortcutManager[] = "enable-profile-shortcut-manager";

--- a/chrome/common/chrome_switches.h
+++ b/chrome/common/chrome_switches.h
@@ -245,6 +245,7 @@ extern const char kMakeChromeDefault[];
 #endif  // BUILDFLAG(IS_MAC)
 
 #if BUILDFLAG(IS_WIN)
+extern const char kDisableWindows10CustomTitlebar[];
 extern const char kEnableProfileShortcutManager[];
 extern const char kFromInstaller[];
 extern const char kHideIcons[];


### PR DESCRIPTION
The recent removal of `--disable-windows10-custom-titlebar` switch meant that Chromium and its derivatives can no longer have consistent appearance for users with visual style/theme customization (such as AeroGlass, WindowBlinds, MicaForEveryone, etc.). There is simply no reason to draw a custom title bar when the native one can do just fine, and conforms to whatever the theme the user is set.