### PR TITLE
Fix for Issue 1485846: Dangling pointer in content/browser/notifications/notification_event_dispatcher_impl_unittest.cc

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1378,6 +1378,7 @@ Upendra Gowda <upendrag.gowda@gmail.com>
 Utzcoz <utzcoz@gmail.com>
 UwU UwU <uwu7586@gmail.com>
 Uzair Jaleel <uzair.jaleel@samsung.com>
+Uzochukwu Ochogu <uzoochogu@yahoo.com>
 Vadim Gorbachev <bmsdave@gmail.com>
 Vaibhav Agrawal <vaibhav1.a@samsung.com>
 Valentin Ilie <valentin.ilie@intel.com>

--- a/content/browser/notifications/notification_event_dispatcher_impl_unittest.cc
+++ b/content/browser/notifications/notification_event_dispatcher_impl_unittest.cc
@@ -89,7 +89,8 @@ class NotificationEventDispatcherImplTest : public RenderViewHostTestHarness {
   NotificationEventDispatcherImplTest& operator=(
       const NotificationEventDispatcherImplTest&) = delete;
 
-  ~NotificationEventDispatcherImplTest() override { delete dispatcher_; }
+  // NotificationEventDispatcherImpl singleton will handle clean-up by itself.
+  ~NotificationEventDispatcherImplTest() override { dispatcher_ = nullptr; }
 
   // Waits until the task runner managing the Mojo connection has finished.
   void WaitForMojoTasksToComplete() { task_environment()->RunUntilIdle(); }
@@ -104,7 +105,7 @@ class NotificationEventDispatcherImplTest : public RenderViewHostTestHarness {
   };
   // Using a raw pointer because NotificationEventDispatcherImpl is a singleton
   // with private constructor and destructor, so unique_ptr is not an option.
-  raw_ptr<NotificationEventDispatcherImpl, DanglingUntriaged> dispatcher_;
+  raw_ptr<NotificationEventDispatcherImpl> dispatcher_;
 };
 
 TEST_F(NotificationEventDispatcherImplTest,


### PR DESCRIPTION
Fixes issue [1485846](https://bugs.chromium.org/p/chromium/issues/detail?id=1485846&can=2&q=Hotlist%3DGoodFirstBug%20&colspec=ID%20Pri%20M%20Cr%20Status%20Owner%20Summary%20OS%20Modified&x=m&y=releaseblock&cells=tiles)
Fixed the dangling pointer issue. Removed delete operation in destructor and removed dangling pointer annotation.
