### PR TITLE
Add Utf8 function when WTF::String have chinese character

### DIFF
--- a/third_party/blink/renderer/platform/wtf/text/wtf_string.cc
+++ b/third_party/blink/renderer/platform/wtf/text/wtf_string.cc
@@ -26,6 +26,7 @@
 #include <stdarg.h>
 
 #include <algorithm>
+#include <sstream>
 
 #include "base/functional/callback.h"
 #include "base/logging.h"
@@ -473,6 +474,21 @@ std::string String::Latin1() const {
   }
 
   return latin1;
+}
+
+std::string String::Utf8ByStd() const {
+  unsigned length = this->length();
+  if (!length)
+    return std::string();
+
+  if (Is8Bit()) {
+    return Utf8();
+  }
+
+  std::u16string u16str(this->Characters16(), this->length());
+  std::ostringstream oss;
+  oss << u16str;
+  return oss.str();
 }
 
 String String::Make8BitFrom16BitSource(const UChar* source, wtf_size_t length) {

--- a/third_party/blink/renderer/platform/wtf/text/wtf_string.h
+++ b/third_party/blink/renderer/platform/wtf/text/wtf_string.h
@@ -177,6 +177,7 @@ class WTF_EXPORT String {
       UTF8ConversionMode mode = kLenientUTF8Conversion) const {
     return StringView(*this).Utf8(mode);
   }
+  [[nodiscard]] std::string Utf8ByStd() const;
 
   UChar operator[](wtf_size_t index) const {
     if (!impl_ || index >= impl_->length())


### PR DESCRIPTION
Add a function whose return value is std::string when WTF::String have chinese character.
For example:
WTF::String wtf_str("test_更多_str");
std::string str = wtf_str.Utf8ByStd();
Write(str.c_str(), str.size());