### PR TITLE
Wayland: Adjust scale factor calculation

### DIFF
--- a/ui/ozone/platform/wayland/host/xdg_output.cc
+++ b/ui/ozone/platform/wayland/host/xdg_output.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "base/environment.h"
+#include "base/nix/xdg_util.h"
 #include "ui/ozone/platform/wayland/host/xdg_output.h"
 
 #include <xdg-output-unstable-v1-client-protocol.h>
@@ -63,7 +65,17 @@ void XDGOutput::UpdateMetrics(bool surface_submission_in_pixel_coordinates,
         std::max(physical_size.width(), physical_size.height());
     const float max_logical_side =
         std::max(logical_size.width(), logical_size.height());
-    metrics.scale_factor = max_physical_side / max_logical_side;
+
+    std::unique_ptr<base::Environment> env = base::Environment::Create();
+    switch (base::nix::GetDesktopEnvironment(env.get())) {
+      case base::nix::DESKTOP_ENVIRONMENT_KDE5:
+      case base::nix::DESKTOP_ENVIRONMENT_KDE6:
+        metrics.scale_factor = std::round((max_physical_side / max_logical_side) * 100) / 100.0f;
+        break;
+      default:
+        metrics.scale_factor = max_physical_side / max_logical_side;
+        break;
+    }
   }
 }
 


### PR DESCRIPTION
By design, the protocol implies that clients must use the scaling factor that came from the compositor.
But in fact, only KDE following that rule.

Although Chrome still uses scale calculation from
physical / logical dimensions, we need to fix the resulting scale at least for the KDE session, as it is unusable now with scale factors like 1.5.

So, we need to adjust the calculation of the scale factor by rounding the ratio of the maximum physical side to the maximum logical side to two decimal places for KDE.

KDE, physical 2560, logical 1707:
2560 / 1.5 = 1707
2560 / 1707 = 1.4997070884592854
Scale factor: 150%
Fractional scale value is 180: 180 / 120 = 1.5
Note: When the scale factor is set to 1.5, the interface is clear

GNOME, physical 2560, logical 1712:
2560 / 1.5 = 1712
2560 / 1712 = 1.4953271028037383
Scale factor: 150%
Fractional scale value is 179: 179 / 120 = 1.4916666666666667 Note: When the scale factor is set to 1.4916666666666667, the interface is blurred

Sway, physical 2560, logical 1706:
2560 / 1.5 = 1706
2560 / 1706 = 1.5005861664712778
Scale factor: 150%
Fractional scale value is 180: 180 / 120 = 1.5
Note: When the scale factor is set to 1.5, the interface is blurred