### PR TITLE
Try the next render node before returning

### DIFF
--- a/media/gpu/vaapi/vaapi_wrapper.cc
+++ b/media/gpu/vaapi/vaapi_wrapper.cc
@@ -1535,7 +1535,7 @@ void VADisplayStateSingleton::PreSandboxInitialization() {
       continue;
     }
     va_display_state.drm_fd_ = base::ScopedFD(drm_file.TakePlatformFile());
-    return;
+    continue;
   }
 }
 


### PR DESCRIPTION
On PRIME systems usually renderD129 is the onboard graphics and renderD128 is the discrete GPU, allow the loop to continue to the next node