### PR TITLE
Update featureless-004.html

### DIFF
--- a/third_party/blink/web_tests/external/wpt/css/selectors/featureless-004.html
+++ b/third_party/blink/web_tests/external/wpt/css/selectors/featureless-004.html
@@ -20,15 +20,13 @@
         :not(:not(:host)) .t2 {
           background-color: green;
         }
-
-
-        :not(aside) .t3 {
+        :not(:host(:not(aside))) .t3 {
           background-color: red;
         }
-        :not(.foo:host) .t4 {
+        :not(:host).foo .t4 {
           background-color: red;
         }
-        :not(:host > .foo) .t5 {
+        :not(:host) > .foo .t5 {
           background-color: red;
         }
       </style>


### PR DESCRIPTION
1. Summary of Changes:

  Refined CSS selectors to improve the application of styles to shadow DOM elements.
   Addressed issues related to the :host pseudo-class and other pseudo-classes like :not() and :is() to ensure more predictable 
   and  accurate style targeting.

2. Changes:

    a.)Updated .t3 selector:
             Previous: The selector applied styles based on whether the parent was not an aside element, potentially leading to 
             unintended styles.
            New: Refined to :not(:host(:not(aside))) .t3, ensuring the style is applied when the host is not an aside element.

     b.)  Refined .t4 selector:

            Previous: The style applied if the host element did not have the .foo class.
            New: Updated to :not(:host).foo .t4, ensuring the style is applied if the host does have the .foo class.

      c.) Adjusted .t5 selector:

          Previous: The style applied if the host did not contain a .foo child element.
         New: Updated to :not(:host) > .foo .t5, ensuring the style is applied when .foo is a direct child of the host element.

3. Why this Change:

    The changes ensure that the styles are applied correctly based on the host element's relationship with other DOM elements.
    Improved maintainability and consistency of the CSS code, ensuring better future scalability.

4. Test Plan:
   Verify that the background color of .t3, .t4, and .t5 elements reflects the intended logic based on the host element's 
   properties.
   Ensure no unintended styles are applied due to ambiguity in previous selector definitions.

All test cases are passing showing green .

![issue solved](https://github.com/user-attachments/assets/35197da0-858f-4385-bd12-872cb4f0f712)
