### PR TITLE
Remove seemingly invalid memset on packed structure on arm

### DIFF
--- a/mojo/core/ports/event.cc
+++ b/mojo/core/ports/event.cc
@@ -114,10 +114,6 @@ static_assert(sizeof(UpdatePreviousPeerEventData) % kPortsMessageAlignment == 0,
 
 }  // namespace
 
-Event::PortDescriptor::PortDescriptor() {
-  memset(padding, 0, sizeof(padding));
-}
-
 Event::~Event() = default;
 
 // static

--- a/mojo/core/ports/event.h
+++ b/mojo/core/ports/event.h
@@ -70,17 +70,17 @@ class COMPONENT_EXPORT(MOJO_CORE_PORTS) Event {
 
 #pragma pack(push, 1)
   struct PortDescriptor {
-    PortDescriptor();
+    PortDescriptor() = default;
 
-    NodeName peer_node_name;
-    PortName peer_port_name;
-    NodeName referring_node_name;
-    PortName referring_port_name;
-    uint64_t next_sequence_num_to_send;
-    uint64_t next_sequence_num_to_receive;
-    uint64_t last_sequence_num_to_receive;
-    bool peer_closed;
-    char padding[7];
+    NodeName peer_node_name = {};
+    PortName peer_port_name = {};
+    NodeName referring_node_name = {};
+    PortName referring_port_name = {};
+    uint64_t next_sequence_num_to_send = 0;
+    uint64_t next_sequence_num_to_receive = 0;
+    uint64_t last_sequence_num_to_receive = 0;
+    bool peer_closed = false;
+    char padding[7] = {0};
   };
 #pragma pack(pop)
 


### PR DESCRIPTION
As reported in https://bugs.gentoo.org/950305, on arm target, calling memset on a packed structure seem to cause alignment issue.

Workaround this by using default member initialization instead of a raw memset, which leverage existing default constructors.