### PR TITLE
fix Uncontrolled data used in path expression

### DIFF
--- a/tools/md_browser/md_browser.py
+++ b/tools/md_browser/md_browser.py
@@ -296,7 +296,9 @@ class Handler(http.server.SimpleHTTPRequestHandler):
     if relative_to is None:
       relative_to = self.server.top_level
     assert not relpath.startswith(os.sep)
-    path = os.path.join(relative_to, relpath)
+    path = os.path.normpath(os.path.join(relative_to, relpath))
+    if not path.startswith(relative_to):
+      raise ValueError(f"Access to {relpath} is not allowed.")
     with codecs.open(path, encoding='utf-8') as fp:
       return fp.read()
 


### PR DESCRIPTION
https://github.com/chromium/chromium/blob/89807c0bc81efb37ce1aba285a9e579ce398fefa/tools/md_browser/md_browser.py#L300-L300

address the issue will validate the `relpath` parameter in the `_Read` method to ensure it does not allow access to files outside the intended directory. Specifically:
1. Normalize the constructed path using `os.path.normpath`.
2. Verify that the normalized path starts with the `relative_to` directory.
3. Raise an exception if the validation fails.

This fix ensures that even if the `do_GET` method's validation is bypassed or flawed, the `_Read` method will enforce the directory constraint.

Accessing files using paths constructed from user-controlled data can allow an attacker to access unexpected resources. This can result in sensitive information being revealed or deleted, or an attacker being able to influence behavior by modifying unexpected files.


## POC
a file name is read from an HTTP request and then used to access a file. However, a malicious user could enter a file name that is an absolute path, such as `"/etc/passwd"`. 

it appears that the user is restricted to opening a file within the `"user"` home directory. However, a malicious user could enter a file name containing special characters, the string `"../../../etc/passwd"` will result in the code reading the file located at `"/server/static/images/../../../etc/passwd"`, which is the system's password file. This file would then be sent back to the user, giving them access to all the system's passwords. Note that a user could also use an absolute path here, since the result of `os.path.join("/server/static/images/", "/etc/passwd")` is `"/etc/passwd"`.

In the third the path used to access the file system is normalized before being checked against a known prefix. This ensures that regardless of the user input, the resulting path is safe.
```py
import os.path
from flask import Flask, request, abort

app = Flask(__name__)

@app.route("/user_picture1")
def user_picture1():
    filename = request.args.get('p')
    # BAD: This could read any file on the file system
    data = open(filename, 'rb').read()
    return data

@app.route("/user_picture2")
def user_picture2():
    base_path = '/server/static/images'
    filename = request.args.get('p')
    # BAD: This could still read any file on the file system
    data = open(os.path.join(base_path, filename), 'rb').read()
    return data

@app.route("/user_picture3")
def user_picture3():
    base_path = '/server/static/images'
    filename = request.args.get('p')
    #GOOD -- Verify with normalised version of path
    fullpath = os.path.normpath(os.path.join(base_path, filename))
    if not fullpath.startswith(base_path):
        raise Exception("not allowed")
    data = open(fullpath, 'rb').read()
    return data
```
## References
[Path Traversal](https://owasp.org/www-community/attacks/Path_Traversal)
[werkzeug.utils.secure_filename](http://werkzeug.pocoo.org/docs/utils/#werkzeug.utils.secure_filename)
[CWE-22](https://cwe.mitre.org/data/definitions/22.html)
[CWE-23](https://cwe.mitre.org/data/definitions/23.html)
[CWE-36](https://cwe.mitre.org/data/definitions/36.html)
[CWE-73](https://cwe.mitre.org/data/definitions/73.html)
[CWE-99](https://cwe.mitre.org/data/definitions/99.html)