### PR TITLE
fix restartTargetX where drawRestartButton in dino_game/game_over_panel

### DIFF
--- a/components/neterror/resources/dino_game/game_over_panel.ts
+++ b/components/neterror/resources/dino_game/game_over_panel.ts
@@ -199,7 +199,7 @@ export class GameOverPanel {
     let restartSourceWidth = dimensions.restartWidth;
     let restartSourceHeight = dimensions.restartHeight;
     const restartTargetX =
-        (this.canvasDimensions.width / 2) - (dimensions.restartHeight / 2);
+        (this.canvasDimensions.width / 2) - (dimensions.restartWidth / 2);
     const restartTargetY = this.canvasDimensions.height / 2;
 
     if (IS_HIDPI) {


### PR DESCRIPTION
…el.ts

At the method `drawRestartButton` of Class `GameOverPanel`, we use `(this.canvasDimensions.width / 2) - (dimensions.restartHeight / 2)` for restartTargetX.
See here:
https://github.com/chromium/chromium/blob/81bfd8bb2db53d115e8028208c37f98474ef6d91/components/neterror/resources/dino_game/game_over_panel.ts#L201

But why an `Xpos = some.width - another.height` ?
Maybe it is `Xpos = some.width - another.width `.
So we fix it like this `(this.canvasDimensions.width / 2) - (dimensions.restartWidth / 2)`.

One more thing.
Why there is NO error and NO abnormal that we can see or feel? Just for `defaultPanelDimensions.restartWidth = 36; defaultPanelDimensions.restartHeight = 32;`, they are nearly the same.
See here:
https://github.com/chromium/chromium/blob/81bfd8bb2db53d115e8028208c37f98474ef6d91/components/neterror/resources/dino_game/game_over_panel.ts#L58